### PR TITLE
Update README.md with info about rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,18 @@ while True:
     pmk.update()
 ```
 
+## Rotation
+
+If you're using your keypad in a different orientation, you can use the `.rotate()` method to make sure your key numbers are in the logical order. 
+
+The default PMK key arrangement doesn't match the Pico RGB Keypad Base (`RGBKeypadBase`) circuitboard labels. You can fix it by rotating the keys 90 degrees
+
+```
+pmk = PMK(Hardware())
+pmk.rotate(90)
+```
+
+
 ## An interlude on timing!
 
 Another **super** important thing is **not to include any `time.sleep()`s in


### PR DESCRIPTION
This issue reports that the Pimoroni RGB Keybad keys don't match their labels. https://github.com/pimoroni/pmk-circuitpython/issues/10

I've updated the readme to suggest a fix, and also to documen the `rotate()` method and its possible use cases.